### PR TITLE
Increases precision of nonce

### DIFF
--- a/bitstampy/calls.py
+++ b/bitstampy/calls.py
@@ -72,7 +72,7 @@ class APIPrivateCall(APICall):
         self.api_secret = api_secret
 
     def _get_nonce(self):
-        return str(int(time.time()*1e6))
+        return str(int(time.time() * 1e6))
 
     def call(self, **params):
         nonce = self._get_nonce()


### PR DESCRIPTION
When making two calls in rapid succession the existing nonce logic generated api-errors.
