### PR TITLE
Fixed import error in python3.5

### DIFF
--- a/bitstampy/api.py
+++ b/bitstampy/api.py
@@ -1,4 +1,4 @@
-import calls
+from . import calls
 
 # Constants
 BUY_LIMIT_ORDER_TYPE_BUY = 0


### PR DESCRIPTION
Replaced "import calls" to "from . import calls" in api.py

Tested on python 3.5.1 and 2.7.11
