### PR TITLE
Sub-Account support with the Bitstamp API

### DIFF
--- a/bitstampy/api.py
+++ b/bitstampy/api.py
@@ -152,3 +152,16 @@ def withdrawal_requests(client_id, api_key, api_secret):
         calls.APIWithdrawalRequestsCall(client_id, api_key, api_secret)
         .call()
     )
+
+def transfer_to_main(client_id, api_key, api_secret, amount, currency):
+    return (
+        calls.APITransferToMainCall(client_id, api_key, api_secret)
+         .call(amount=amount, currency=currency)
+    )
+
+def transfer_from_main(client_id, api_key, api_secret, amount, currency, subAccount):
+    return (
+        calls.APITransferFromMainCall(client_id, api_key, api_secret)
+         .call(amount=amount, currency=currency, subAccount=subAccount)
+    )
+

--- a/bitstampy/calls.py
+++ b/bitstampy/calls.py
@@ -72,7 +72,7 @@ class APIPrivateCall(APICall):
         self.api_secret = api_secret
 
     def _get_nonce(self):
-        return str(int(time.time() * 1e6))
+        return str(int(time.time() * 1e7 ))
 
     def call(self, **params):
         nonce = self._get_nonce()
@@ -236,3 +236,9 @@ class APIWithdrawalRequestsCall(APIPrivateCall):
         for wr in response:
             wr['datetime'] = dt(wr['datetime'])
             wr['amount'] = Decimal(wr['amount'])
+
+class APITransferToMainCall(APIPrivateCall):
+    url = 'v2/transfer-to-main/'
+
+class APITransferFromMainCall(APIPrivateCall):
+    url = 'v2/transfer-from-main/'


### PR DESCRIPTION
Now supports transfers from Bitstamp Main account to sub-account and from sub-account to main... Also the nonce is more robust (one decimal place greater)